### PR TITLE
Feat(SCRUM-46): 메이트 탐색 지역 조건 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "io.ourfit"
-version = "1.0.1"
+version = "1.0.2"
 
 java {
     toolchain {

--- a/src/main/java/io/ourfit/api/domain/user/data/dto/internal/MateCandidateSearchDto.java
+++ b/src/main/java/io/ourfit/api/domain/user/data/dto/internal/MateCandidateSearchDto.java
@@ -11,14 +11,14 @@ import java.util.Set;
 /**
  * 사용자 검색 DTO
  *
- * @param region3 요청 사용자의 동네(동/읍/면)
+ * @param region2 요청 사용자의 동네(시/군/구) (<i>지역 3에서 임시 변경</i>)
  * @param nickname 검색할 닉네임
  * @param gender 검색할 성별
  * @param preferredTimes 검색할 선호 시간대
  * @param workoutTypes 검색할 운동 종류
  */
 public record MateCandidateSearchDto(
-    String region3,
+    String region2,
     String nickname,
     GenderType gender,
     List<TimePrefrenceType> preferredTimes,
@@ -26,7 +26,7 @@ public record MateCandidateSearchDto(
 
   public static MateCandidateSearchDto fromRequest(MateCandidateSearchRequest request, User user) {
     return new MateCandidateSearchDto(
-        user.getRegion3(),
+        user.getRegion2(),
         request.nickname(),
         GenderType.findByName(request.gender()).orElse(null),
         StreamUtils.mapToList(request.preferredTimes(), TimePrefrenceType::valueOf),

--- a/src/main/java/io/ourfit/api/infra/persistence/user/impl/UserQRepositoryImpl.java
+++ b/src/main/java/io/ourfit/api/infra/persistence/user/impl/UserQRepositoryImpl.java
@@ -63,7 +63,7 @@ public class UserQRepositoryImpl implements UserQRepository {
             qUser.ne(requestedUser),
             qUser.deletedAt.isNull(),
             isNotMatchedWithMate(),
-            region3Eqauls(searchDto),
+            region2Eqauls(searchDto),
             nicknameLike(searchDto),
             genderEquals(searchDto),
             preferredTimesIn(searchDto),
@@ -118,7 +118,7 @@ public class UserQRepositoryImpl implements UserQRepository {
                         qUser.deletedAt.isNull(),
                         isNotMatchedWithMate(),
                         nicknameLike(searchDto),
-                        region3Eqauls(searchDto),
+                        region2Eqauls(searchDto),
                         genderEquals(searchDto),
                         preferredTimesIn(searchDto),
                         workoutsIn(searchDto))
@@ -135,8 +135,8 @@ public class UserQRepositoryImpl implements UserQRepository {
         .notExists();
   }
 
-  private static BooleanExpression region3Eqauls(MateCandidateSearchDto searchDto) {
-    return qUser.region3.eq(searchDto.region3());
+  private static BooleanExpression region2Eqauls(MateCandidateSearchDto searchDto) {
+    return qUser.region2.eq(searchDto.region2());
   }
 
   private static BooleanExpression nicknameLike(MateCandidateSearchDto searchDto) {


### PR DESCRIPTION
- 지역3(읍/면/동)이 같은 사용자 → 지역2(시/군/구)가 같은 사용자
  - 메이트에 아무도 검색 안되는 케이스 방지하기 위해 지역 범위 확대 